### PR TITLE
Add quotes around api_password when setting it

### DIFF
--- a/jobs/caddy/templates/warm_buildpack_cache.sh.erb
+++ b/jobs/caddy/templates/warm_buildpack_cache.sh.erb
@@ -8,7 +8,7 @@ cells=<%= properties.performance_tests.num_cells %>
 
 api_url=<%= properties.stress_tests.api %>
 api_user=<%= properties.stress_tests.admin_user %>
-api_password=<%= properties.stress_tests.admin_password %>
+api_password='<%= properties.stress_tests.admin_password %>'
 cf login -a $api_url -u $api_user -p $api_password <%= properties.stress_tests.skip_ssl_validation ? "--skip-ssl-validation" : "" %>
 
 cleanup() {


### PR DESCRIPTION
Without these there will be a syntax error if the password
contains (.

$ api_password=a(b
-bash: syntax error near unexpected token `('
