### PR TITLE
Make diego-stress-test ssl verification configurable

### DIFF
--- a/jobs/cedar/spec
+++ b/jobs/cedar/spec
@@ -51,3 +51,10 @@ properties:
     description: Maximum amount of app push and start failures for cedar to tolerate, as a fraction of the total number of apps to push.
     default: 0.05
 
+  cedar.use_ssl:
+    description: Whether to use https when curling app endpoints
+    default: false
+
+  cedar.skip_verify_certificate:
+    description: Whether to ignore invalid TLS certificates
+    default: false

--- a/jobs/cedar/templates/cedar_script.erb
+++ b/jobs/cedar/templates/cedar_script.erb
@@ -46,6 +46,8 @@ seed_apps() {
 			-n=<%= p("cedar.num_batches") %> \
 			-k=<%= p("cedar.max_in_flight")%> \
 			-domain=<%= p("cedar.domain") %> \
+			-use-ssl=<%= p("cedar.use_ssl") %> \
+			-skip-verify-certificate=<%= p("cedar.skip_verify_certificate") %> \
 			-payload=$APP_BIN_PATH \
 			-config=$CONFIG_PATH \
 			-max-polling-errors=<%= p("cedar.max_polling_errors") %> \
@@ -70,6 +72,8 @@ deploy_arborist_apps() {
 		-n=<%= (p("cedar.num_batches").to_f/25).ceil %> \
 		-k=<%= p("cedar.max_in_flight")%> \
 		-domain=<%= p("cedar.domain") %> \
+		-use-ssl=<%= p("cedar.use_ssl") %> \
+		-skip-verify-certificate=<%= p("cedar.skip_verify_certificate") %> \
 		-payload=/var/vcap/packages/cedar/assets/temp-app \
 		-config=/var/vcap/packages/cedar/config_extra.json \
 		-timeout=<%= p("cedar.timeout")%> \
@@ -86,6 +90,7 @@ run_arborist_batch() {
 		-result-file=$ARBORIST_LOG_DIR/arborist-output.json \
 		-duration=<%= p("arborist.duration") %> \
 		-request-interval=<%= p("arborist.request_interval") %> \
+		-skip-verify-certificate=<%= p("cedar.skip_verify_certificate") %> \
 	1> $ARBORIST_LOG_DIR/arborist.stdout.log \
 	2> $ARBORIST_LOG_DIR/arborist.stderr.log
 }


### PR DESCRIPTION
This commit adds the configuration properties introduced in [diego-stress-tests #2](https://github.com/cloudfoundry/diego-stress-tests/pull/2) to the bosh release.