### PR TITLE
Additing num_spaces parameter - number of spaces for cedar tests

### DIFF
--- a/jobs/cedar/spec
+++ b/jobs/cedar/spec
@@ -36,6 +36,10 @@ properties:
     description: Max number of request failures for cedar to tolerate when verifying an app has started.
     default: 1
 
+  cedar.num_spaces:
+    description: Number of spaces for cedar
+    default: 10
+
   cedar.num_batches:
     description: Number of app batches for each cedar invocation to push.
     default: 10

--- a/jobs/cedar/templates/cedar_script.erb
+++ b/jobs/cedar/templates/cedar_script.erb
@@ -9,6 +9,7 @@ CONFIG_PATH=/var/vcap/packages/cedar/config.json
 CEDAR_LOG_DIR=/var/vcap/sys/log/cedar
 ARBORIST_LOG_DIR=/var/vcap/sys/log/arborist
 
+CEDAR_NUM_SPACES=<%= p("cedar.num_spaces") %>
 CEDAR_SPACE_PREFIX=cedar-space
 ARBORIST_SPACE=arborist-space
 CEDAR_APP_PREFIX=cedar-app
@@ -23,7 +24,7 @@ usage() {
 }
 
 create_spaces() {
-	for i in {1..10}; do
+	for i in `seq 1 $CEDAR_NUM_SPACES`; do
 		cf create-space -o <%= p("cedar.org") %> $CEDAR_SPACE_PREFIX-$i
 	done
 	cf create-space -o <%= p("cedar.org") %> $ARBORIST_SPACE
@@ -35,7 +36,7 @@ seed_apps() {
 		space_counter=$1
 	fi
 
-	for counter in `seq $space_counter 10`; do
+	for counter in `seq $space_counter $CEDAR_NUM_SPACES`; do
 
 		space=$CEDAR_SPACE_PREFIX-$counter
 

--- a/manifest-generation/perf.yml
+++ b/manifest-generation/perf.yml
@@ -53,6 +53,7 @@ properties:
     admin_user: (( property_overrides.cc_admin_user || "" )) # unfortunate hack because we can't get it from cf manifest
     admin_password: (( property_overrides.cc_admin_password || "" ))  # unfortunate hack because we can't get it from cf manifest
     org: (( property_overrides.org ))
+    num_spaces: (( property_overrides.cedar.num_spaces || nil ))
     num_batches: (( property_overrides.cedar.num_batches || nil ))
     max_in_flight: (( property_overrides.cedar.max_in_flight || nil ))
     tolerance:  (( property_overrides.cedar.tolerance || nil ))


### PR DESCRIPTION
Adding parameter for configuring the number of spaces used by cedar. Thus we can avoid too many application in a single space.